### PR TITLE
Add logic to seperate per whitespace rather than a length

### DIFF
--- a/src/components/fortuneWheel/index.vue
+++ b/src/components/fortuneWheel/index.vue
@@ -77,11 +77,20 @@ const canvasDefaultConfig = {
 
 function getStrArray (str: string, len: number) {
   const arr = []
+
+  str += ' '
   while (str !== '') {
-    const text = str.substr(0, len)
-    str = str.replace(text, '')
-    arr.push(text)
+    const index = str.lastIndexOf(' ', len)
+
+    if (index === -1) {
+      arr.push(str)
+      break
+    }
+
+    arr.push(str.substr(0, index))
+    str = str.substring(index + 1)
   }
+
   return arr
 }
 


### PR DESCRIPTION
I've noticed that the package right now, just cuts off strings per length. Without using an actual word break, this PR will make sure this will do.

Example:
![image](https://user-images.githubusercontent.com/10142882/103097814-cbee3200-4608-11eb-9d95-8a2bc0c39cbe.png)
